### PR TITLE
Added links pointing to checksum files

### DIFF
--- a/source/download.html.erb
+++ b/source/download.html.erb
@@ -216,7 +216,9 @@ priority: 0.9
         </p>
     </div>
     <p>
-        <a href="#requirements" data-modal>System Requirements</a>
+        <a href="http://downloads.activestate.com/Komodo/releases/9.0.0/MD5SUM">MD5</a>
+        and <a href="http://downloads.activestate.com/Komodo/releases/9.0.0/SHA256SUM">SHA256</a> Checksums
+        | <a href="#requirements" data-modal>System Requirements</a>
     </p>
 </div>
 


### PR DESCRIPTION
Let's give [some visibility](https://twitter.com/alct/status/586194807351078914) to these checksum files :)

![noname](https://cloud.githubusercontent.com/assets/360770/7077542/eb69a524-df11-11e4-8926-8ef97733b2e4.png)