### PR TITLE
added fix for packages clearing issue and z index for the chat screen

### DIFF
--- a/source/assets/stylesheets/_modules/layout.scss
+++ b/source/assets/stylesheets/_modules/layout.scss
@@ -265,6 +265,7 @@ aside
         border-top-left-radius: 3px;
         border-top-right-radius: 3px;
         background: #294E5F;
+        z-index: 99;
     }
 
     table, tr, td, a

--- a/source/assets/stylesheets/_modules/pages/resources.scss
+++ b/source/assets/stylesheets/_modules/pages/resources.scss
@@ -225,17 +225,30 @@
     {
         display: inline-block;
         text-align: left;
-        width: 40%;
-        margin: 25px;
+        width: 45%;
+        margin: 2.5%;
         background: #F9F9F9;
         border: 1px solid #E0E0E0;
         border-radius: 2px;
         vertical-align: top;
-        
         @include media(max-width 750px)
         {
             display: block;
             width: auto;
+        }
+        
+        @include media(min-width 750px)
+        {
+            &:nth-of-type(odd)
+            {
+                float: left;
+                clear: left;
+            }
+            &:nth-of-type(even)
+            {
+                float: right;
+                clear: right;
+            }
         }
         
         .preview


### PR DESCRIPTION
the packages page had a clearing issue (as seen below)
![snap 2015-08-02 at 12 39 35](https://cloud.githubusercontent.com/assets/3530262/9025887/a4de6ac0-3918-11e5-901f-37ccb84fd4ce.png)

Created a fix by adding floats and clears, also when i tested the responsive i found a bug in the chat screen.
Added a z-index 99 to always stay on top on (on mobile the chat window was going below some elements)

tested it on firefox and crome using stylish the code i used
<pre>
 @media(min-width: 750px)
        {
          
           .document-resources article > ul:not(.trail) > li, 
            .document-resource-category article > ul:not(.trail) > li {
              width: 45%;
              margin: 2.5%;
            }
            .document-resources article > ul:not(.trail) > li:nth-of-type(odd), 
          .document-resource-category article > ul:not(.trail) > li:nth-of-type(odd) {
            float: left;
            clear: left;
          }

          .document-resources article > ul:not(.trail) > li:nth-of-type(even), 
          .document-resource-category article > ul:not(.trail) > li:nth-of-type(even) {
            float: right;
            clear: right;
          }
        }
</pre>

