### PR TITLE
Update footer bug reporting URL

### DIFF
--- a/data/footer.yml
+++ b/data/footer.yml
@@ -33,7 +33,7 @@ nav:
           link: "http://docs.komodoide.com/"
         - 
           name: "Report Bug"
-          link: "http://bugs.activestate.com/enter_bug.cgi?product=Komodo"
+          link: "https://github.com/Komodo/KomodoEdit/issues"
           target: "_blank"
   support: 
     - 


### PR DESCRIPTION
Komodo bugs no longer go to bugzilla.  In fact, it is not possible to open a new bug there (for Komodo, at least).