### PR TITLE
Fixed broken google fonts link, fixes #12

### DIFF
--- a/source/templates/layouts/layout.erb
+++ b/source/templates/layouts/layout.erb
@@ -27,7 +27,7 @@
         <!-- Styles -->
         <%= stylesheet_link_tag "style" %>
 
-        <link href='http://fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,700italic,400,600,700|Kalam' rel='stylesheet' type='text/css'>
+        <link href='https://fonts.googleapis.com/css?family=Kalam|Open+Sans:400,400i,600,600i,700,700i' rel='stylesheet' type='text/css'>
         
     </head>
     <body class="<%= current_page.data.disableFooter ? "footer-disabled" : "" %>">


### PR DESCRIPTION
Noticed the google fonts weren't loading correct for a while.
Updated the url so it should now is looking fine again.

Before:

![afbeelding](https://user-images.githubusercontent.com/3530262/31464067-874c37f0-aed0-11e7-9cf7-580e6643d2dd.png)

After:

![afbeelding](https://user-images.githubusercontent.com/3530262/31464076-93d4a214-aed0-11e7-9ca8-be81f8ef482c.png)

